### PR TITLE
Remove spaces from project name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "CYF React and Express Template",
+  "name": "CYF-React-and-Express-Template",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
yarn doesn't like them, and yarn is default on render

We probably want to switch away from yarn, but this is an easy foot-gun